### PR TITLE
build: add changelog popup to web accessible resources

### DIFF
--- a/platform/chrome/manifest.json
+++ b/platform/chrome/manifest.json
@@ -57,7 +57,7 @@
   ],
   "web_accessible_resources": [
     {
-      "resources": ["public/menu.html"],
+      "resources": ["public/menu.html", "public/changelog_popup.html"],
       "matches": ["<all_urls>"]
     }
   ]

--- a/platform/firefox/manifest.json
+++ b/platform/firefox/manifest.json
@@ -55,7 +55,8 @@
         "dist/tvp-changelog-popup.css"
       ],
       "web_accessible_resources": [
-        "public/menu.html"
+        "public/menu.html",
+        "public/changelog_popup.html"
       ]
     }
   ]

--- a/platform/opera/manifest.json
+++ b/platform/opera/manifest.json
@@ -57,7 +57,7 @@
   ],
   "web_accessible_resources": [
     {
-      "resources": ["public/menu.html"],
+      "resources": ["public/menu.html", "public/changelog_popup.html"],
       "matches": ["<all_urls>"]
     }
   ]


### PR DESCRIPTION
### Summary
Adds `changelog_popup.html` to the `web_accessible_resources` array in all browser manifest files (Chrome, Firefox, and Opera).

### Details
Without this change, the changelog popup cannot be accessed from a web context, causing the changelog feature to fail to display when triggered within the extension.

### Changes
- Updated `platform/chrome/manifest.json`
- Updated `platform/firefox/manifest.json`
- Updated `platform/opera/manifest.json`

### Related Commit
`7d61743`

### Related Issue
Fixes #94

### Verification
Tested locally on:
- Chrome (v latest)
- Firefox (v latest)

Changelog popup now loads successfully when invoked.
