### PR TITLE
fix(ui): exclude timeframe text from hover styling (Issue #21)

### DIFF
--- a/public/tvp-context-menu.scss
+++ b/public/tvp-context-menu.scss
@@ -8,14 +8,14 @@
   padding: 0.4rem 0;
   border-radius: 4px;
 
-  p:hover {
+  p:not(.timeframe-text):hover {
     cursor: pointer;
     background: variables.$lightGrey;
   }
 
   // Dark mode
   &:not(.tvp-light) {
-    p:hover {
+    p:not(.timeframe-text):hover {
       cursor: pointer;
       background: variables.$darkGrey;
     }

--- a/src/features/AutoTimeframeColors.ts
+++ b/src/features/AutoTimeframeColors.ts
@@ -75,6 +75,7 @@ class AutoTimeframeColors extends Feature {
             // Text containing the timeframe
             const colorText = document.createElement('p');
             colorText.innerText = timeframe;
+            colorText.className = 'timeframe-text';
             colorContainer.appendChild(colorText);
 
             // The color square itself


### PR DESCRIPTION
This PR fixes the hover effect issue in the color picker context menu where **non-clickable timeframe labels** were incorrectly showing hover behavior (background highlight and cursor change).

---

## ⚙️ Changes Made

1. **CSS Update**

   * Updated `public/tvp-context-menu.scss` to prevent hover styles on static elements.
   * Replaced selector

     ```scss
     p:hover
     ```

     with

     ```scss
     p:not(.timeframe-text):hover
     ```

     so only interactive items receive hover effects.

2. **TypeScript Update**

   * Updated `src/features/AutoTimeframeColors.ts` to add the `timeframe-text` class to non-interactive timeframe labels (lines 75–78).
   * Ensures correct class targeting in the context menu.

---

## ✅ Result

* Timeframe labels are **no longer highlighted** or **showing pointer cursors** when hovered.
* Only interactive menu items now respond visually to hover.
* UI behavior is cleaner and consistent with the intended design.

---

Fixes #21  
**Type:** UI Bug Fix
**Scope:** `AutoTimeframeColors`, `tvp-context-menu.scss`

