### PR TITLE
fix(changelog): add missing changelog popup CSS to Chrome and Opera manifests

### DIFF
--- a/platform/chrome/manifest.json
+++ b/platform/chrome/manifest.json
@@ -51,7 +51,8 @@
         "dist/tvp-background.css",
         "dist/tvp-context-menu.css",
         "dist/tvp-menu-handle.css",
-        "dist/tvp-light.css"
+        "dist/tvp-light.css",
+        "dist/tvp-changelog-popup.css"
       ]
     }
   ],

--- a/platform/opera/manifest.json
+++ b/platform/opera/manifest.json
@@ -51,7 +51,8 @@
         "dist/tvp-background.css",
         "dist/tvp-context-menu.css",
         "dist/tvp-menu-handle.css",
-        "dist/tvp-light.css"
+        "dist/tvp-light.css",
+        "dist/tvp-changelog-popup.css"
       ]
     }
   ],


### PR DESCRIPTION
**Description**
Summary: Adds `dist/tvp-changelog-popup.css` to `content_scripts[0].css` in `platform/chrome/manifest.json` and `platform/opera/manifest.json` so the changelog popup renders with styles. Firefox already included it. 
*  Fixes #113 

Changes:

* Chrome manifest: append `dist/tvp-changelog-popup.css` after `dist/tvp-light.css`. 
* Opera manifest: same update. 

Rationale:  #113   identified the CSS was missing only for Chrome and Opera. This PR aligns those manifests with Firefox and fixes the unstyled popup. 

Testing:

1. Build Chrome and Opera.
2. Load unpacked extension.
3. Open the changelog popup.
4. Verify styles load and layout matches Firefox. Evidence in diff shows the CSS entry present in both manifests. 

Risk: Low. Manifest-only change. No runtime logic affected.
