### PR TITLE
chore(release): update changelog and bump version to 5.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@types/dompurify": "^3.0.5",
         "@types/node": "^24.7.2",
+        "adm-zip": "^0.5.16",
         "nodemon": "^3.0.1",
         "sass": "^1.93.3",
         "typescript": "^5.9.3",
@@ -811,6 +812,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1937,6 +1939,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,9 @@
         "@types/dompurify": "^3.0.5",
         "@types/node": "^24.7.2",
         "nodemon": "^3.0.1",
-        "sass": "^1.93.2",
+        "sass": "^1.93.3",
         "typescript": "^5.9.3",
-        "web-ext": "^9.0.0"
+        "web-ext": "^9.1.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -145,9 +145,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -352,9 +352,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@mdn/browser-compat-data": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-7.1.7.tgz",
-      "integrity": "sha512-bpWZ7hidvjrwNWcMngZ8nTMTxn8WhnQntsGqEYgPr1vjy66kfwfDVizwXg6PvsgoANZ7nhuRBmvzjpCMk4ITDw==",
+      "version": "7.1.15",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-7.1.15.tgz",
+      "integrity": "sha512-njPXYbxog+meuYAFsVygS6TfIj3/Pi6r0T9wZ+1MIV3/P+L7qlfnIVW5kPNKIHr4WQhvEnsmAXx+KPCKi+kVrA==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -829,15 +829,15 @@
       }
     },
     "node_modules/addons-linter": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/addons-linter/-/addons-linter-8.0.0.tgz",
-      "integrity": "sha512-atU+Y6zKv22LUSYU6JQ7f7no+l3etUp/XFpQglClL5gO7CPaLq03/1wcvBs5qQl0icGLY6ZnM60flnrsp0otNA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/addons-linter/-/addons-linter-8.4.0.tgz",
+      "integrity": "sha512-cd5XZ2W+6aNXvOVtd67Ehzv960/ZkXIuTBndyrtlYQZVDqHbQI4FJtNGcL+CsUqucuPrUKxDtNZZBfAchPOFrg==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "@fluent/syntax": "0.19.0",
         "@fregante/relaxed-json": "2.0.0",
-        "@mdn/browser-compat-data": "7.1.7",
+        "@mdn/browser-compat-data": "7.1.15",
         "addons-moz-compare": "1.3.0",
         "addons-scanner-utils": "9.13.0",
         "ajv": "8.17.1",
@@ -854,8 +854,8 @@
         "fast-json-patch": "3.1.1",
         "image-size": "2.0.2",
         "json-merge-patch": "1.0.2",
-        "pino": "9.11.0",
-        "semver": "7.7.2",
+        "pino": "9.13.0",
+        "semver": "7.7.3",
         "source-map-support": "0.5.21",
         "upath": "2.0.1",
         "yargs": "17.7.2",
@@ -866,6 +866,29 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/addons-linter/node_modules/pino": {
+      "version": "9.13.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.13.0.tgz",
+      "integrity": "sha512-SpTXQhkQXekIKEe7c887S3lk3v90Q+/HVRZVyNAhe98PQc++6I5ec/R0pciH8/CciXjCoVZIZfRNicbC6KZgnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "slow-redact": "^0.3.0",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
       }
     },
     "node_modules/addons-moz-compare": {
@@ -2195,16 +2218,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-redact": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
-      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
@@ -3636,14 +3649,13 @@
       }
     },
     "node_modules/pino": {
-      "version": "9.11.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-9.11.0.tgz",
-      "integrity": "sha512-+YIodBB9sxcWeR8PrXC2K3gEDyfkUuVEITOcbqrfcj+z5QW4ioIcqZfYFbrLTYLsmAwunbS7nfU/dpBB6PZc1g==",
+      "version": "9.12.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.12.0.tgz",
+      "integrity": "sha512-0Gd0OezGvqtqMwgYxpL7P0pSHHzTJ0Lx992h+mNlMtRVfNnqweWmf0JmRWk5gJzHalyd2mxTzKjhiNbGS2Ztfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0",
-        "fast-redact": "^3.1.1",
         "on-exit-leak-free": "^2.1.0",
         "pino-abstract-transport": "^2.0.0",
         "pino-std-serializers": "^7.0.0",
@@ -3651,6 +3663,7 @@
         "quick-format-unescaped": "^4.0.3",
         "real-require": "^0.2.0",
         "safe-stable-stringify": "^2.3.1",
+        "slow-redact": "^0.3.0",
         "sonic-boom": "^4.0.1",
         "thread-stream": "^3.0.0"
       },
@@ -4007,9 +4020,9 @@
       "license": "MIT"
     },
     "node_modules/sass": {
-      "version": "1.93.2",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.93.2.tgz",
-      "integrity": "sha512-t+YPtOQHpGW1QWsh1CHQ5cPIr9lbbGZLZnbihP/D/qZj/yuV68m8qarcV17nvkOX81BCrvzAlq2klCQFZghyTg==",
+      "version": "1.93.3",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.93.3.tgz",
+      "integrity": "sha512-elOcIZRTM76dvxNAjqYrucTSI0teAF/L2Lv0s6f6b7FOwcwIuA357bIE871580AjHJuSvLIRUosgV+lIWx6Rgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4065,9 +4078,9 @@
       "license": "ISC"
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4130,6 +4143,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/slow-redact": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/slow-redact/-/slow-redact-0.3.2.tgz",
+      "integrity": "sha512-MseHyi2+E/hBRqdOi5COy6wZ7j7DxXRz9NkseavNYSvvWC06D8a5cidVZX3tcG5eCW3NIyVU4zT63hw0Q486jw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sonic-boom": {
       "version": "4.2.0",
@@ -4584,15 +4604,15 @@
       }
     },
     "node_modules/web-ext": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/web-ext/-/web-ext-9.0.0.tgz",
-      "integrity": "sha512-QheVP1seAMB5EOnTxlR8mOgQU85ik44K6FedEzqmOEq9kpCy1NrycekMw1mk8qwlkeN0RbJmEK65NIDCRthy1Q==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/web-ext/-/web-ext-9.1.0.tgz",
+      "integrity": "sha512-K4hv/WBgRgj8gdl0ExUHBPva3Rhh1hjm6v10HcB9Rn8Mnx4CPezXYyDZ1p3MiMSd+Sms9mQW8L0AubppJ6uMwA==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "@babel/runtime": "7.28.4",
         "@devicefarmer/adbkit": "3.3.8",
-        "addons-linter": "8.0.0",
+        "addons-linter": "8.4.0",
         "camelcase": "8.0.0",
         "chrome-launcher": "1.2.0",
         "debounce": "1.2.1",
@@ -4607,7 +4627,7 @@
         "node-notifier": "10.0.1",
         "open": "10.2.0",
         "parse-json": "8.3.0",
-        "pino": "9.11.0",
+        "pino": "9.12.0",
         "promise-toolbox": "0.21.0",
         "source-map-support": "0.5.21",
         "strip-bom": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "dev-firefox": "node scripts/dev.js firefox",
     "dev-chrome": "node scripts/dev.js chrome",
     "dev-opera": "node scripts/dev.js opera",
-    "build": "node scripts/build.js",
-    "build-firefox": "node scripts/build.js firefox",
-    "build-chrome": "node scripts/build.js chrome",
-    "build-opera": "node scripts/build.js opera"
+    "build": "npm install && node scripts/build.js",
+    "build-firefox": "npm install && node scripts/build.js firefox",
+    "build-chrome": "npm install && node scripts/build.js chrome",
+    "build-opera": "npm install && node scripts/build.js opera"
   },
   "keywords": [
     "tradingview",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "@types/dompurify": "^3.0.5",
     "@types/node": "^24.7.2",
     "nodemon": "^3.0.1",
-    "sass": "^1.93.2",
+    "sass": "^1.93.3",
     "typescript": "^5.9.3",
-    "web-ext": "^9.0.0"
+    "web-ext": "^9.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@types/dompurify": "^3.0.5",
     "@types/node": "^24.7.2",
+    "adm-zip": "^0.5.16",
     "nodemon": "^3.0.1",
     "sass": "^1.93.3",
     "typescript": "^5.9.3",

--- a/platform/chrome/manifest.json
+++ b/platform/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "TradingviewPlus",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "author": "Tiqur",
 
   "description": "Changes line color according to current timeframe, price scale scrolling, line style changing, and various other hotkeys.",

--- a/platform/firefox/manifest.json
+++ b/platform/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "TradingviewPlus",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "author": "Tiqur",
 
   "description": "Changes line color according to current timeframe, price scale scrolling, line style changing, and various other hotkeys.",

--- a/platform/opera/manifest.json
+++ b/platform/opera/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "TradingviewPlus",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "author": "Tiqur",
 
   "description": "Changes line color according to current timeframe, price scale scrolling, line style changing, and various other hotkeys.",

--- a/public/changelog_popup.html
+++ b/public/changelog_popup.html
@@ -3,10 +3,11 @@
   <h3 id='tvp-changelog-version'></h3>
   <hr/>
   <ul>
-    <li>Added ability to toggle AutoTimeframeColors using hotkey</li>
-    <li>Fixed AutoTimeframeColors color changes not saving locally</li>
-    <li>Added dynamic timeframe support for AutoTimeframeColors</li>
-    <li>Added changelog pop-up menu</li>
+    <li>Improved stability and performance of TimeframeScroll</li>
+    <li>Unified and upgraded Hotkey System with dynamic suppression and mouse-hotkey fixes</li>
+    <li>Fixed display issues with timeframe text hover styling</li>
+    <li>Repaired compatibility with new TradingView line width and style changes</li>
+    <li>Ensured changelog popup proper display across browsers</li>
   </ul>
   <button id="tvp-changelog-confirm">OK</button>
 </dialog>

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@
 declare const chrome: any;
 declare const DOMPurify: any;
 
-const VERSION = "v5.0.4";
+const VERSION = "v5.0.5";
 
 // For chrome extension
 if (typeof browser === "undefined") {


### PR DESCRIPTION
**Description:**
This release updates the TradingviewPlus changelog and increments the version to **v5.0.5** across all browser manifests.

### Summary of changes

* Updated changelog popup with simplified, user-friendly feature list
* Bumped version to 5.0.5 in Chrome, Firefox, and Opera manifests
* Minor dependency updates in `package.json` and `package-lock.json`
* Removed outdated changelog entries
* Updated displayed version in `src/main.ts`

### Highlights for users

* Improved TimeframeScroll stability and performance
* Unified and enhanced Hotkey System
* Fixed hover styling for timeframe labels
* Restored compatibility with TradingView’s latest line style changes
* Ensured changelog popup displays properly on all supported browsers

**Reviewer suggestion:** @Tiqur
**Closing keywords:** Closes #118 
