### PR TITLE
fix(AutoTimeframeColors): update color palette DOM selector

### DIFF
--- a/src/features/AutoTimeframeColors.ts
+++ b/src/features/AutoTimeframeColors.ts
@@ -1,5 +1,5 @@
 // All TV default colors
-const defaultColors = ["rgb(255, 255, 255)","rgb(209, 212, 220)","rgb(178, 181, 190)","rgb(149, 152, 161)","rgb(120, 123, 134)","rgb(93, 96, 107)","rgb(67, 70, 81)","rgb(42, 46, 57)","rgb(19, 23, 34)","rgb(0, 0, 0)","rgb(242, 54, 69)","rgb(255, 152, 0)","rgb(255, 235, 59)","rgb(76, 175, 80)","rgb(8, 153, 129)","rgb(0, 188, 212)","rgb(41, 98, 255)","rgb(103, 58, 183)","rgb(156, 39, 176)","rgb(233, 30, 99)","rgb(252, 203, 205)","rgb(255, 224, 178)","rgb(255, 249, 196)","rgb(200, 230, 201)","rgb(172, 229, 220)","rgb(178, 235, 242)","rgb(187, 217, 251)","rgb(209, 196, 233)","rgb(225, 190, 231)","rgb(248, 187, 208)","rgb(250, 161, 164)","rgb(255, 204, 128)","rgb(255, 245, 157)","rgb(165, 214, 167)","rgb(112, 204, 189)","rgb(128, 222, 234)","rgb(144, 191, 249)","rgb(179, 157, 219)","rgb(206, 147, 216)","rgb(244, 143, 177)","rgb(247, 124, 128)","rgb(255, 183, 77)","rgb(255, 241, 118)","rgb(129, 199, 132)","rgb(66, 189, 168)","rgb(77, 208, 225)","rgb(91, 156, 246)","rgb(149, 117, 205)","rgb(186, 104, 200)","rgb(240, 98, 146)","rgb(247, 82, 95)","rgb(255, 167, 38)","rgb(255, 238, 88)","rgb(102, 187, 106)","rgb(34, 171, 148)","rgb(38, 198, 218)","rgb(49, 121, 245)","rgb(126, 87, 194)","rgb(171, 71, 188)","rgb(236, 64, 122)","rgb(178, 40, 51)","rgb(245, 124, 0)","rgb(251, 192, 45)","rgb(56, 142, 60)","rgb(5, 102, 86)","rgb(0, 151, 167)","rgb(24, 72, 204)","rgb(81, 45, 168)","rgb(123, 31, 162)","rgb(194, 24, 91)","rgb(128, 25, 34)","rgb(230, 81, 0)","rgb(245, 127, 23)","rgb(27, 94, 32)","rgb(0, 51, 42)","rgb(0, 96, 100)","rgb(12, 50, 153)","rgb(49, 27, 146)","rgb(74, 20, 140)","rgb(136, 14, 79)"]
+const defaultColors = ["rgb(255, 255, 255)", "rgb(209, 212, 220)", "rgb(178, 181, 190)", "rgb(149, 152, 161)", "rgb(120, 123, 134)", "rgb(93, 96, 107)", "rgb(67, 70, 81)", "rgb(42, 46, 57)", "rgb(19, 23, 34)", "rgb(0, 0, 0)", "rgb(242, 54, 69)", "rgb(255, 152, 0)", "rgb(255, 235, 59)", "rgb(76, 175, 80)", "rgb(8, 153, 129)", "rgb(0, 188, 212)", "rgb(41, 98, 255)", "rgb(103, 58, 183)", "rgb(156, 39, 176)", "rgb(233, 30, 99)", "rgb(252, 203, 205)", "rgb(255, 224, 178)", "rgb(255, 249, 196)", "rgb(200, 230, 201)", "rgb(172, 229, 220)", "rgb(178, 235, 242)", "rgb(187, 217, 251)", "rgb(209, 196, 233)", "rgb(225, 190, 231)", "rgb(248, 187, 208)", "rgb(250, 161, 164)", "rgb(255, 204, 128)", "rgb(255, 245, 157)", "rgb(165, 214, 167)", "rgb(112, 204, 189)", "rgb(128, 222, 234)", "rgb(144, 191, 249)", "rgb(179, 157, 219)", "rgb(206, 147, 216)", "rgb(244, 143, 177)", "rgb(247, 124, 128)", "rgb(255, 183, 77)", "rgb(255, 241, 118)", "rgb(129, 199, 132)", "rgb(66, 189, 168)", "rgb(77, 208, 225)", "rgb(91, 156, 246)", "rgb(149, 117, 205)", "rgb(186, 104, 200)", "rgb(240, 98, 146)", "rgb(247, 82, 95)", "rgb(255, 167, 38)", "rgb(255, 238, 88)", "rgb(102, 187, 106)", "rgb(34, 171, 148)", "rgb(38, 198, 218)", "rgb(49, 121, 245)", "rgb(126, 87, 194)", "rgb(171, 71, 188)", "rgb(236, 64, 122)", "rgb(178, 40, 51)", "rgb(245, 124, 0)", "rgb(251, 192, 45)", "rgb(56, 142, 60)", "rgb(5, 102, 86)", "rgb(0, 151, 167)", "rgb(24, 72, 204)", "rgb(81, 45, 168)", "rgb(123, 31, 162)", "rgb(194, 24, 91)", "rgb(128, 25, 34)", "rgb(230, 81, 0)", "rgb(245, 127, 23)", "rgb(27, 94, 32)", "rgb(0, 51, 42)", "rgb(0, 96, 100)", "rgb(12, 50, 153)", "rgb(49, 27, 146)", "rgb(74, 20, 140)", "rgb(136, 14, 79)"]
 
 class AutoTimeframeColors extends Feature {
   canvas!: HTMLCanvasElement;
@@ -46,7 +46,7 @@ class AutoTimeframeColors extends Feature {
         // Get position of dots
         const dots = document.getElementById(`${this.getName()}-svg-dots`);
         if (!dots) return;
-        const [x, y] = [dots.getBoundingClientRect().x, dots.getBoundingClientRect().y] 
+        const [x, y] = [dots.getBoundingClientRect().x, dots.getBoundingClientRect().y]
 
 
         // Launch timeframe colors config
@@ -98,9 +98,9 @@ class AutoTimeframeColors extends Feature {
           });
         } else {
 
-            const textNode = document.createElement('p');
-            textNode.innerText = "Please favorite some timeframes to use this feature"
-            container.appendChild(textNode);
+          const textNode = document.createElement('p');
+          textNode.innerText = "Please favorite some timeframes to use this feature"
+          container.appendChild(textNode);
         }
 
         cm.renderElement(container);
@@ -130,15 +130,15 @@ class AutoTimeframeColors extends Feature {
         /* Update ColorPickerMenu position */
         // Calculate position
         const offset = cm.element.getBoundingClientRect().right - cm.element.getBoundingClientRect().left + 2;
-        colorPickerCm.updatePosition([x+offset, y]);
+        colorPickerCm.updatePosition([x + offset, y]);
       })
     ]);
   }
 
-  onKeyDown() {};
-  onMouseMove() {};
-  onKeyUp() {};
-  onMouseWheel() {};
+  onKeyDown() { };
+  onMouseMove() { };
+  onKeyUp() { };
+  onMouseWheel() { };
 
 
   removeColor(key: string) {
@@ -190,8 +190,8 @@ class AutoTimeframeColors extends Feature {
       colorElement.style.background = dc;
       colorElement.className = 'color-square';
       colorPickerContainer.appendChild(colorElement);
-      
-      colorElement.addEventListener('click', () => {colorChooseCb(colorIndex)});
+
+      colorElement.addEventListener('click', () => { colorChooseCb(colorIndex) });
     });
 
     return colorPickerContainer;
@@ -206,7 +206,7 @@ class AutoTimeframeColors extends Feature {
     const currentTimeframe: string | null = (
       // Method 1: Original selector with class containing "isActive"
       (document.querySelector('#header-toolbar-intervals div button[class*="isActive"]') as HTMLElement)?.textContent ||
-      
+
       // Method 2: Fallback - check for any class containing 'active' or 'selected'
       (() => {
         const allTimeframeButtons = Array.from(document.querySelectorAll('#header-toolbar-intervals div button')) as HTMLElement[];
@@ -218,10 +218,10 @@ class AutoTimeframeColors extends Feature {
         );
         return foundElement?.textContent || null;
       })() ||
-      
+
       // Method 3: Fallback - check for aria-selected attribute
       (document.querySelector('#header-toolbar-intervals div button[aria-selected="true"]') as HTMLElement)?.textContent ||
-      
+
       // Method 4: Fallback - check for any attribute containing 'active' or 'selected'
       (() => {
         const allTimeframeButtons = Array.from(document.querySelectorAll('#header-toolbar-intervals div button')) as HTMLElement[];
@@ -229,7 +229,7 @@ class AutoTimeframeColors extends Feature {
           for (let i = 0; i < button.attributes.length; i++) {
             const attr = button.attributes[i];
             if (attr.name.includes('active') || attr.value.includes('active') ||
-                attr.name.includes('selected') || attr.value.includes('selected')) {
+              attr.name.includes('selected') || attr.value.includes('selected')) {
               return true;
             }
           }
@@ -237,10 +237,10 @@ class AutoTimeframeColors extends Feature {
         });
         return foundElement?.textContent || null;
       })() ||
-      
+
       null
     );
-    
+
     if (currentTimeframe == null) return;
 
     // Wait for toolbar
@@ -249,7 +249,10 @@ class AutoTimeframeColors extends Feature {
       waitForElm('[data-name="line-tool-color"]').then((colorElement) => {
         if (colorElement) {
           (colorElement as HTMLElement).click();
-          const allColors = document.querySelectorAll('[data-name="line-tool-color-menu"] div:not([class]) button');
+          let allColors = document.querySelectorAll('[data-qa-id="line-tool-color-menu"] [data-role="swatch"]');
+          if (!allColors.length) {
+            allColors = document.querySelectorAll('[data-name="line-tool-color-menu"] div:not([class]) button');
+          }
           const local_colors = this.getConfigValue('colors');
           if (allColors.length > 0 && local_colors[currentTimeframe] !== undefined && allColors[local_colors[currentTimeframe]]) {
             (allColors[local_colors[currentTimeframe]] as HTMLElement).click();


### PR DESCRIPTION
- Added support for new `data-qa-id` TradingView UI elements
- Maintained fallback to legacy `data-name` attributes for older cached versions