### PR TITLE
Feat & Fix: Add Limit Order Only toggle and resolve Auto Timeframe Colors issue

### DIFF
--- a/platform/chrome/manifest.json
+++ b/platform/chrome/manifest.json
@@ -24,6 +24,7 @@
         "dist/utils/ContextMenuListItem.js",
         "dist/utils/ContextMenu.js",
         "dist/utils/checkDuplicateHotkeys.js",
+        "dist/utils/findActiveMenuItem.js",
         "dist/features/AutoScale.js",
         "dist/features/LogScale.js",
         "dist/features/AutoTimeframeColors.js",

--- a/platform/chrome/manifest.json
+++ b/platform/chrome/manifest.json
@@ -44,6 +44,7 @@
         "dist/features/MoveTimeRight.js",
         "dist/features/TimeframeScroll.js",
         "dist/features/ZoomChart.js",
+        "dist/features/LimitOrderOnly.js",
         "dist/main.js"
       ],
       "css": [

--- a/platform/firefox/manifest.json
+++ b/platform/firefox/manifest.json
@@ -24,6 +24,7 @@
         "dist/utils/ContextMenuListItem.js",
         "dist/utils/ContextMenu.js",
         "dist/utils/checkDuplicateHotkeys.js",
+        "dist/utils/findActiveMenuItem.js",
         "dist/features/AutoScale.js",
         "dist/features/LogScale.js",
         "dist/features/AutoTimeframeColors.js",

--- a/platform/firefox/manifest.json
+++ b/platform/firefox/manifest.json
@@ -44,6 +44,7 @@
         "dist/features/MoveTimeRight.js",
         "dist/features/TimeframeScroll.js",
         "dist/features/ZoomChart.js",
+        "dist/features/LimitOrderOnly.js",
         "dist/main.js"
       ],
       "css": [

--- a/platform/opera/manifest.json
+++ b/platform/opera/manifest.json
@@ -24,6 +24,7 @@
         "dist/utils/ContextMenuListItem.js",
         "dist/utils/ContextMenu.js",
         "dist/utils/checkDuplicateHotkeys.js",
+        "dist/utils/findActiveMenuItem.js",
         "dist/features/AutoScale.js",
         "dist/features/LogScale.js",
         "dist/features/AutoTimeframeColors.js",

--- a/platform/opera/manifest.json
+++ b/platform/opera/manifest.json
@@ -44,6 +44,7 @@
         "dist/features/MoveTimeRight.js",
         "dist/features/TimeframeScroll.js",
         "dist/features/ZoomChart.js",
+        "dist/features/LimitOrderOnly.js",
         "dist/main.js"
       ],
       "css": [

--- a/src/features/AutoTimeframeColors.ts
+++ b/src/features/AutoTimeframeColors.ts
@@ -202,42 +202,18 @@ class AutoTimeframeColors extends Feature {
     if (!this.isEnabled() || !this.canvas) return;
     if (e.target !== this.canvas && !this.canvas.contains(e.target as Node)) return;
 
-    // Get current timeframe with multiple fallback methods
+    // Get current timeframe — space-padded class check avoids false match on isInteractive-xxx
     const currentTimeframe: string | null = (
-      // Method 1: Original selector with class containing "isActive"
-      (document.querySelector('#header-toolbar-intervals div button[class*="isActive"]') as HTMLElement)?.textContent ||
-
-      // Method 2: Fallback - check for any class containing 'active' or 'selected'
       (() => {
-        const allTimeframeButtons = Array.from(document.querySelectorAll('#header-toolbar-intervals div button')) as HTMLElement[];
-        const foundElement = allTimeframeButtons.find(button =>
-          Array.from(button.classList).some(className =>
-            className.toLowerCase().includes('active') ||
-            className.toLowerCase().includes('selected')
-          )
-        );
-        return foundElement?.textContent || null;
-      })() ||
-
-      // Method 3: Fallback - check for aria-selected attribute
-      (document.querySelector('#header-toolbar-intervals div button[aria-selected="true"]') as HTMLElement)?.textContent ||
-
-      // Method 4: Fallback - check for any attribute containing 'active' or 'selected'
-      (() => {
-        const allTimeframeButtons = Array.from(document.querySelectorAll('#header-toolbar-intervals div button')) as HTMLElement[];
-        const foundElement = allTimeframeButtons.find(button => {
-          for (let i = 0; i < button.attributes.length; i++) {
-            const attr = button.attributes[i];
-            if (attr.name.includes('active') || attr.value.includes('active') ||
-              attr.name.includes('selected') || attr.value.includes('selected')) {
-              return true;
-            }
-          }
-          return false;
+        const buttons = Array.from(document.querySelectorAll('#header-toolbar-intervals div button'));
+        const activeBtn = buttons.find(b => {
+          const cn = ' ' + (b as HTMLElement).className + ' ';
+          return cn.includes(' isActive') || cn.includes(' active-');
         });
-        return foundElement?.textContent || null;
+        return activeBtn ? (activeBtn as HTMLElement).textContent : null;
       })() ||
-
+      (document.querySelector('#header-toolbar-intervals div button[aria-selected="true"]') as HTMLElement)?.textContent ||
+      (document.querySelector('#header-toolbar-intervals div button[aria-pressed="true"]') as HTMLElement)?.textContent ||
       null
     );
 
@@ -245,22 +221,35 @@ class AutoTimeframeColors extends Feature {
 
     // Wait for toolbar
     waitForElm('.floating-toolbar-react-widgets__button').then((e) => {
-      // Wait for the color selector to be available before clicking
       waitForElm('[data-name="line-tool-color"]').then((colorElement) => {
-        if (colorElement) {
+        if (!colorElement) return;
+        const swatchSelector = '[data-qa-id="line-tool-color-menu"] [data-role="swatch"]';
+
+        // Only click to open the menu if it's not already open.
+        // Clicking when open would toggle it closed, causing a race with waitForElm.
+        if (!document.querySelector(swatchSelector)) {
           (colorElement as HTMLElement).click();
-          let allColors = document.querySelectorAll('[data-qa-id="line-tool-color-menu"] [data-role="swatch"]');
+        }
+
+        // waitForElm resolves instantly if menu is open, or waits for it to appear
+        waitForElm(swatchSelector).then(() => {
+          // Prioritize new data-qa-id selector; fall back to old data-name selector
+          let allColors = document.querySelectorAll(swatchSelector);
           if (!allColors.length) {
             allColors = document.querySelectorAll('[data-name="line-tool-color-menu"] div:not([class]) button');
           }
           const local_colors = this.getConfigValue('colors');
-          if (allColors.length > 0 && local_colors[currentTimeframe] !== undefined && allColors[local_colors[currentTimeframe]]) {
-            (allColors[local_colors[currentTimeframe]] as HTMLElement).click();
+          const colorIdx = local_colors[currentTimeframe];
+          if (allColors.length > 0 && colorIdx !== undefined && allColors[colorIdx]) {
+            (allColors[colorIdx] as HTMLElement).click();
           }
-        }
+        });
       });
     })
   }
+
+
+
 
   init() {
     this.initDefaultColors();
@@ -270,4 +259,4 @@ class AutoTimeframeColors extends Feature {
       this.canvas = document.querySelectorAll('.chart-gui-wrapper canvas')[1] as HTMLCanvasElement;
     })
   }
-}
+}

--- a/src/features/AutoTimeframeColors.ts
+++ b/src/features/AutoTimeframeColors.ts
@@ -223,18 +223,11 @@ class AutoTimeframeColors extends Feature {
     waitForElm('.floating-toolbar-react-widgets__button').then((e) => {
       waitForElm('[data-name="line-tool-color"]').then((colorElement) => {
         if (!colorElement) return;
-        const swatchSelector = '[data-qa-id="line-tool-color-menu"] [data-role="swatch"]';
+        (colorElement as HTMLElement).click();
 
-        // Only click to open the menu if it's not already open.
-        // Clicking when open would toggle it closed, causing a race with waitForElm.
-        if (!document.querySelector(swatchSelector)) {
-          (colorElement as HTMLElement).click();
-        }
-
-        // waitForElm resolves instantly if menu is open, or waits for it to appear
-        waitForElm(swatchSelector).then(() => {
-          // Prioritize new data-qa-id selector; fall back to old data-name selector
-          let allColors = document.querySelectorAll(swatchSelector);
+        // Wait for color swatches to render after clicking color button
+        waitForElm('[data-qa-id="line-tool-color-menu"] [data-role="swatch"]').then(() => {
+          let allColors = document.querySelectorAll('[data-qa-id="line-tool-color-menu"] [data-role="swatch"]');
           if (!allColors.length) {
             allColors = document.querySelectorAll('[data-name="line-tool-color-menu"] div:not([class]) button');
           }

--- a/src/features/AutoTimeframeColors.ts
+++ b/src/features/AutoTimeframeColors.ts
@@ -1,5 +1,5 @@
 // All TV default colors
-const defaultColors = ["rgb(255, 255, 255)","rgb(209, 212, 220)","rgb(178, 181, 190)","rgb(149, 152, 161)","rgb(120, 123, 134)","rgb(93, 96, 107)","rgb(67, 70, 81)","rgb(42, 46, 57)","rgb(19, 23, 34)","rgb(0, 0, 0)","rgb(242, 54, 69)","rgb(255, 152, 0)","rgb(255, 235, 59)","rgb(76, 175, 80)","rgb(8, 153, 129)","rgb(0, 188, 212)","rgb(41, 98, 255)","rgb(103, 58, 183)","rgb(156, 39, 176)","rgb(233, 30, 99)","rgb(252, 203, 205)","rgb(255, 224, 178)","rgb(255, 249, 196)","rgb(200, 230, 201)","rgb(172, 229, 220)","rgb(178, 235, 242)","rgb(187, 217, 251)","rgb(209, 196, 233)","rgb(225, 190, 231)","rgb(248, 187, 208)","rgb(250, 161, 164)","rgb(255, 204, 128)","rgb(255, 245, 157)","rgb(165, 214, 167)","rgb(112, 204, 189)","rgb(128, 222, 234)","rgb(144, 191, 249)","rgb(179, 157, 219)","rgb(206, 147, 216)","rgb(244, 143, 177)","rgb(247, 124, 128)","rgb(255, 183, 77)","rgb(255, 241, 118)","rgb(129, 199, 132)","rgb(66, 189, 168)","rgb(77, 208, 225)","rgb(91, 156, 246)","rgb(149, 117, 205)","rgb(186, 104, 200)","rgb(240, 98, 146)","rgb(247, 82, 95)","rgb(255, 167, 38)","rgb(255, 238, 88)","rgb(102, 187, 106)","rgb(34, 171, 148)","rgb(38, 198, 218)","rgb(49, 121, 245)","rgb(126, 87, 194)","rgb(171, 71, 188)","rgb(236, 64, 122)","rgb(178, 40, 51)","rgb(245, 124, 0)","rgb(251, 192, 45)","rgb(56, 142, 60)","rgb(5, 102, 86)","rgb(0, 151, 167)","rgb(24, 72, 204)","rgb(81, 45, 168)","rgb(123, 31, 162)","rgb(194, 24, 91)","rgb(128, 25, 34)","rgb(230, 81, 0)","rgb(245, 127, 23)","rgb(27, 94, 32)","rgb(0, 51, 42)","rgb(0, 96, 100)","rgb(12, 50, 153)","rgb(49, 27, 146)","rgb(74, 20, 140)","rgb(136, 14, 79)"]
+const defaultColors = ["rgb(255, 255, 255)", "rgb(209, 212, 220)", "rgb(178, 181, 190)", "rgb(149, 152, 161)", "rgb(120, 123, 134)", "rgb(93, 96, 107)", "rgb(67, 70, 81)", "rgb(42, 46, 57)", "rgb(19, 23, 34)", "rgb(0, 0, 0)", "rgb(242, 54, 69)", "rgb(255, 152, 0)", "rgb(255, 235, 59)", "rgb(76, 175, 80)", "rgb(8, 153, 129)", "rgb(0, 188, 212)", "rgb(41, 98, 255)", "rgb(103, 58, 183)", "rgb(156, 39, 176)", "rgb(233, 30, 99)", "rgb(252, 203, 205)", "rgb(255, 224, 178)", "rgb(255, 249, 196)", "rgb(200, 230, 201)", "rgb(172, 229, 220)", "rgb(178, 235, 242)", "rgb(187, 217, 251)", "rgb(209, 196, 233)", "rgb(225, 190, 231)", "rgb(248, 187, 208)", "rgb(250, 161, 164)", "rgb(255, 204, 128)", "rgb(255, 245, 157)", "rgb(165, 214, 167)", "rgb(112, 204, 189)", "rgb(128, 222, 234)", "rgb(144, 191, 249)", "rgb(179, 157, 219)", "rgb(206, 147, 216)", "rgb(244, 143, 177)", "rgb(247, 124, 128)", "rgb(255, 183, 77)", "rgb(255, 241, 118)", "rgb(129, 199, 132)", "rgb(66, 189, 168)", "rgb(77, 208, 225)", "rgb(91, 156, 246)", "rgb(149, 117, 205)", "rgb(186, 104, 200)", "rgb(240, 98, 146)", "rgb(247, 82, 95)", "rgb(255, 167, 38)", "rgb(255, 238, 88)", "rgb(102, 187, 106)", "rgb(34, 171, 148)", "rgb(38, 198, 218)", "rgb(49, 121, 245)", "rgb(126, 87, 194)", "rgb(171, 71, 188)", "rgb(236, 64, 122)", "rgb(178, 40, 51)", "rgb(245, 124, 0)", "rgb(251, 192, 45)", "rgb(56, 142, 60)", "rgb(5, 102, 86)", "rgb(0, 151, 167)", "rgb(24, 72, 204)", "rgb(81, 45, 168)", "rgb(123, 31, 162)", "rgb(194, 24, 91)", "rgb(128, 25, 34)", "rgb(230, 81, 0)", "rgb(245, 127, 23)", "rgb(27, 94, 32)", "rgb(0, 51, 42)", "rgb(0, 96, 100)", "rgb(12, 50, 153)", "rgb(49, 27, 146)", "rgb(74, 20, 140)", "rgb(136, 14, 79)"]
 
 class AutoTimeframeColors extends Feature {
   canvas!: HTMLCanvasElement;
@@ -46,7 +46,7 @@ class AutoTimeframeColors extends Feature {
         // Get position of dots
         const dots = document.getElementById(`${this.getName()}-svg-dots`);
         if (!dots) return;
-        const [x, y] = [dots.getBoundingClientRect().x, dots.getBoundingClientRect().y] 
+        const [x, y] = [dots.getBoundingClientRect().x, dots.getBoundingClientRect().y]
 
 
         // Launch timeframe colors config
@@ -98,9 +98,9 @@ class AutoTimeframeColors extends Feature {
           });
         } else {
 
-            const textNode = document.createElement('p');
-            textNode.innerText = "Please favorite some timeframes to use this feature"
-            container.appendChild(textNode);
+          const textNode = document.createElement('p');
+          textNode.innerText = "Please favorite some timeframes to use this feature"
+          container.appendChild(textNode);
         }
 
         cm.renderElement(container);
@@ -130,15 +130,15 @@ class AutoTimeframeColors extends Feature {
         /* Update ColorPickerMenu position */
         // Calculate position
         const offset = cm.element.getBoundingClientRect().right - cm.element.getBoundingClientRect().left + 2;
-        colorPickerCm.updatePosition([x+offset, y]);
+        colorPickerCm.updatePosition([x + offset, y]);
       })
     ]);
   }
 
-  onKeyDown() {};
-  onMouseMove() {};
-  onKeyUp() {};
-  onMouseWheel() {};
+  onKeyDown() { };
+  onMouseMove() { };
+  onKeyUp() { };
+  onMouseWheel() { };
 
 
   removeColor(key: string) {
@@ -190,8 +190,8 @@ class AutoTimeframeColors extends Feature {
       colorElement.style.background = dc;
       colorElement.className = 'color-square';
       colorPickerContainer.appendChild(colorElement);
-      
-      colorElement.addEventListener('click', () => {colorChooseCb(colorIndex)});
+
+      colorElement.addEventListener('click', () => { colorChooseCb(colorIndex) });
     });
 
     return colorPickerContainer;
@@ -206,7 +206,7 @@ class AutoTimeframeColors extends Feature {
     const currentTimeframe: string | null = (
       // Method 1: Original selector with class containing "isActive"
       (document.querySelector('#header-toolbar-intervals div button[class*="isActive"]') as HTMLElement)?.textContent ||
-      
+
       // Method 2: Fallback - check for any class containing 'active' or 'selected'
       (() => {
         const allTimeframeButtons = Array.from(document.querySelectorAll('#header-toolbar-intervals div button')) as HTMLElement[];
@@ -218,10 +218,10 @@ class AutoTimeframeColors extends Feature {
         );
         return foundElement?.textContent || null;
       })() ||
-      
+
       // Method 3: Fallback - check for aria-selected attribute
       (document.querySelector('#header-toolbar-intervals div button[aria-selected="true"]') as HTMLElement)?.textContent ||
-      
+
       // Method 4: Fallback - check for any attribute containing 'active' or 'selected'
       (() => {
         const allTimeframeButtons = Array.from(document.querySelectorAll('#header-toolbar-intervals div button')) as HTMLElement[];
@@ -229,7 +229,7 @@ class AutoTimeframeColors extends Feature {
           for (let i = 0; i < button.attributes.length; i++) {
             const attr = button.attributes[i];
             if (attr.name.includes('active') || attr.value.includes('active') ||
-                attr.name.includes('selected') || attr.value.includes('selected')) {
+              attr.name.includes('selected') || attr.value.includes('selected')) {
               return true;
             }
           }
@@ -237,10 +237,10 @@ class AutoTimeframeColors extends Feature {
         });
         return foundElement?.textContent || null;
       })() ||
-      
+
       null
     );
-    
+
     if (currentTimeframe == null) return;
 
     // Wait for toolbar
@@ -249,7 +249,10 @@ class AutoTimeframeColors extends Feature {
       waitForElm('[data-name="line-tool-color"]').then((colorElement) => {
         if (colorElement) {
           (colorElement as HTMLElement).click();
-          const allColors = document.querySelectorAll('[data-name="line-tool-color-menu"] div:not([class]) button');
+          let allColors = document.querySelectorAll('[data-qa-id="line-tool-color-menu"] [data-role="swatch"]');
+          if (!allColors.length) {
+            allColors = document.querySelectorAll('[data-name="line-tool-color-menu"] div:not([class]) button');
+          }
           const local_colors = this.getConfigValue('colors');
           if (allColors.length > 0 && local_colors[currentTimeframe] !== undefined && allColors[local_colors[currentTimeframe]]) {
             (allColors[local_colors[currentTimeframe]] as HTMLElement).click();

--- a/src/features/LimitOrderOnly.ts
+++ b/src/features/LimitOrderOnly.ts
@@ -1,0 +1,129 @@
+class LimitOrderOnly extends Feature {
+  private observer: MutationObserver | null = null;
+
+  constructor() {
+    super(
+      'Limit Order Only',
+      'Enforces Limit orders only (disables Market, Stop, Stop Limit)',
+      false,
+      {
+        key: 'l',
+        ctrl: false,
+        shift: true,
+        alt: false,
+        meta: false
+      },
+      Category.TVP,
+      true
+    );
+    this.addContextMenuOptions([
+    ]);
+  }
+
+  onMouseDown() { };
+  onMouseMove() { };
+  onKeyDown() { };
+  onMouseWheel() { };
+  onKeyUp() { };
+
+  init() {
+    const config = { childList: true, subtree: true, attributes: true, attributeFilter: ['aria-selected'] };
+
+    this.observer = new MutationObserver(() => {
+      this.enforceLimitOnly();
+    });
+
+    this.observer.observe(document.body, config);
+  }
+
+  private enforceLimitOnly() {
+    const tabs = ['Market', 'Stop', 'StopLimit'];
+    if (this.isEnabled()) {
+      tabs.forEach(tabId => {
+        const btn = document.getElementById(tabId) as HTMLButtonElement;
+        if (btn) {
+          btn.style.pointerEvents = 'none';
+          btn.style.opacity = '0.1';
+        }
+      });
+
+      const sellBtn = document.querySelector('[data-name="sell-order-button"]') as HTMLDivElement;
+      if (sellBtn) {
+        sellBtn.style.pointerEvents = 'none';
+        sellBtn.style.opacity = '0.1';
+      }
+
+      const buyBtn = document.querySelector('[data-name="buy-order-button"]') as HTMLDivElement;
+      if (buyBtn) {
+        buyBtn.style.pointerEvents = 'none';
+        buyBtn.style.opacity = '0.1';
+      }
+
+      const radioButtons = Array.from(document.querySelectorAll('button[role="radio"]')) as HTMLButtonElement[];
+      let orderBtn: HTMLButtonElement | null = null;
+      let domBtn: HTMLButtonElement | null = null;
+      radioButtons.forEach(btn => {
+        if (btn.textContent === 'Order') orderBtn = btn as HTMLButtonElement;
+        if (btn.textContent === 'DOM') domBtn = btn as HTMLButtonElement;
+      });
+
+      if (domBtn) {
+        (domBtn as HTMLButtonElement).style.pointerEvents = 'none';
+        (domBtn as HTMLButtonElement).style.opacity = '0.1';
+        if ((domBtn as HTMLButtonElement).getAttribute('aria-checked') === 'true' && orderBtn) {
+          (orderBtn as HTMLButtonElement).click();
+        }
+      }
+
+      const limitBtn = document.getElementById('Limit') as HTMLButtonElement;
+
+      const marketBtn = document.getElementById('Market');
+      const stopBtn = document.getElementById('Stop');
+      const stopLimitBtn = document.getElementById('StopLimit');
+
+      if (limitBtn && (
+        (marketBtn && marketBtn.getAttribute('aria-selected') === 'true') ||
+        (stopBtn && stopBtn.getAttribute('aria-selected') === 'true') ||
+        (stopLimitBtn && stopLimitBtn.getAttribute('aria-selected') === 'true')
+      )) {
+        limitBtn.click();
+      }
+    } else {
+      tabs.forEach(tabId => {
+        const btn = document.getElementById(tabId) as HTMLButtonElement;
+        if (btn) {
+          btn.style.pointerEvents = '';
+          btn.style.opacity = '';
+        }
+      });
+
+      const sellBtn = document.querySelector('[data-name="sell-order-button"]') as HTMLDivElement;
+      if (sellBtn) {
+        sellBtn.style.pointerEvents = '';
+        sellBtn.style.opacity = '';
+      }
+
+      const buyBtn = document.querySelector('[data-name="buy-order-button"]') as HTMLDivElement;
+      if (buyBtn) {
+        buyBtn.style.pointerEvents = '';
+        buyBtn.style.opacity = '';
+      }
+
+      const radioButtons = Array.from(document.querySelectorAll('button[role="radio"]')) as HTMLButtonElement[];
+      let domBtn: HTMLButtonElement | null = null;
+      radioButtons.forEach(btn => {
+        if (btn.textContent === 'DOM') domBtn = btn;
+      });
+
+      if (domBtn) {
+        (domBtn as HTMLButtonElement).style.pointerEvents = '';
+        (domBtn as HTMLButtonElement).style.opacity = '';
+      }
+    }
+  }
+
+  public toggleEnabled() {
+    super.toggleEnabled();
+    this.enforceLimitOnly();
+  }
+}

--- a/src/features/LineStyle.ts
+++ b/src/features/LineStyle.ts
@@ -29,66 +29,23 @@ class LineStyle extends Feature {
 
   onKeyDown(e: KeyboardEvent) {
     if (this.checkTrigger(e) && this.isEnabled()) {
-      // Click line style button
       (document.querySelector('div[data-name="style"]') as HTMLElement)?.click();
 
-      // Line style scrolling
-      const styleMenuContainer = document.querySelector('[data-name="style-menu"] [data-qa-id="menu-inner"]');
-      if (styleMenuContainer) {
-        const styleButtons = Array.from(styleMenuContainer.querySelectorAll('tr[data-role="menuitem"]'));
-        if (styleButtons.length > 0) {
-          // Try multiple methods to find the active button with fallbacks
-          let activeIndex = -1;
-          
-          // Method 1: Check for specific active class
-          activeIndex = styleButtons.findIndex(i => (i as HTMLElement).classList.contains('active-GJX1EXhk'));
-          
-          // Method 2: Fallback - check for any class containing 'active' or 'selected'
-          if (activeIndex === -1) {
-            activeIndex = styleButtons.findIndex(i => {
-              const element = i as HTMLElement;
-              return Array.from(element.classList).some(className =>
-                className.toLowerCase().includes('active') ||
-                className.toLowerCase().includes('selected')
-              );
-            });
-          }
-          
-          // Method 3: Fallback - check for aria-selected attribute
-          if (activeIndex === -1) {
-            activeIndex = styleButtons.findIndex(i =>
-              (i as HTMLElement).getAttribute('aria-selected') === 'true' ||
-              (i as HTMLElement).getAttribute('aria-current') === 'true'
-            );
-          }
-          
-          // Method 4: Fallback - check for any attribute containing 'active' or 'selected'
-          if (activeIndex === -1) {
-            activeIndex = styleButtons.findIndex(i => {
-              const element = i as HTMLElement;
-              for (let j = 0; j < element.attributes.length; j++) {
-                const attr = element.attributes[j];
-                if (attr.name.includes('active') || attr.value.includes('active') ||
-                    attr.name.includes('selected') || attr.value.includes('selected')) {
-                  return true;
-                }
-              }
-              return false;
-            });
-          }
-          
-          // If no active button found, default to first button
-          if (activeIndex === -1) {
-            activeIndex = 0;
-          }
-          
-          const nextIndex = (activeIndex + 1) % styleButtons.length;
-          const nextStyleButton = styleButtons[nextIndex] as HTMLElement;
-          if (nextStyleButton) {
-            nextStyleButton.click();
-          }
-        }
-      }
+      waitForElm('[data-qa-id="style-menu"] [data-qa-id="menu-inner"]').then((styleMenuContainer) => {
+        if (!styleMenuContainer) { console.warn('[TVP LineStyle] Menu container not found'); return; }
+
+        // Primary: tr[data-role="menuitem"] (stable semantic attribute)
+        let styleButtons = Array.from(styleMenuContainer.querySelectorAll('tr[data-role="menuitem"]'));
+        const usingFallback = !styleButtons.length;
+        if (usingFallback) styleButtons = Array.from(styleMenuContainer.querySelectorAll('[data-role="menuitem"]'));
+        if (!styleButtons.length) { console.warn('[TVP LineStyle] No style buttons found'); return; }
+
+        let activeIndex = findActiveMenuItem(styleButtons);
+        if (activeIndex === -1) activeIndex = 0;
+        const nextIndex = (activeIndex + 1) % styleButtons.length;
+        console.log(`[TVP LineStyle] active=${activeIndex} next=${nextIndex} total=${styleButtons.length}${usingFallback ? ' [fallback selector]' : ''}`);
+        (styleButtons[nextIndex] as HTMLElement)?.click();
+      });
     }
   }
 

--- a/src/features/LineWidth.ts
+++ b/src/features/LineWidth.ts
@@ -28,64 +28,27 @@ class LineWidth extends Feature {
 
   onKeyDown(e: KeyboardEvent) {
     if (this.checkTrigger(e) && this.isEnabled()) {
-      // Click line width button
       (document.querySelector('div[data-name="line-tool-width"]') as HTMLElement)?.click();
 
-      // Line width scrolling
-      const widthMenuContainer = document.querySelector('[data-name="line-tool-width-menu"] [data-qa-id="menu-inner"]');
-      if (widthMenuContainer) {
-        const widthButtons = Array.from(widthMenuContainer.querySelectorAll('div.item-jFqVJoPk.item-KdWj36gM.withIcon-jFqVJoPk.withIcon-KdWj36gM'));
+      waitForElm('[data-qa-id="line-tool-width-menu"] [data-qa-id="menu-inner"]').then((widthMenuContainer) => {
+        if (!widthMenuContainer) { console.warn('[TVP LineWidth] Menu container not found'); return; }
 
-        if (widthButtons.length > 0) {
-          // Try multiple methods to find the active button with fallbacks
-          let activeIndex = -1;
-          
-          // Method 1: Check for specific active class
-          activeIndex = widthButtons.findIndex(i => (i as HTMLElement).className.includes('isActive-jFqVJoPk'));
-          
-          // Method 2: Fallback - check for any class containing 'active' or 'selected'
-          if (activeIndex === -1) {
-            activeIndex = widthButtons.findIndex(i => {
-              const element = i as HTMLElement;
-              return Array.from(element.classList).some(className =>
-                className.toLowerCase().includes('active') ||
-                className.toLowerCase().includes('selected')
-              );
-            });
-          }
-          
-          // Method 3: Fallback - check for aria-selected attribute
-          if (activeIndex === -1) {
-            activeIndex = widthButtons.findIndex(i =>
-              (i as HTMLElement).getAttribute('aria-selected') === 'true' ||
-              (i as HTMLElement).getAttribute('aria-current') === 'true'
-            );
-          }
-          
-          // Method 4: Fallback - check for any attribute containing 'active' or 'selected'
-          if (activeIndex === -1) {
-            activeIndex = widthButtons.findIndex(i => {
-              const element = i as HTMLElement;
-              for (let j = 0; j < element.attributes.length; j++) {
-                const attr = element.attributes[j];
-                if (attr.name.includes('active') || attr.value.includes('active') ||
-                    attr.name.includes('selected') || attr.value.includes('selected')) {
-                  return true;
-                }
-              }
-              return false;
-            });
-          }
-          
-          // If no active button found, default to first button
-          if (activeIndex === -1) {
-            activeIndex = 0;
-          }
-          
-          const nextIndex = (activeIndex + 1) % widthButtons.length;
-          (widthButtons[nextIndex] as HTMLElement).click();
+        // Primary: data-role="menuitem" (stable). Fallback: div with 'item' in class (React-generated)
+        let widthButtons = Array.from(widthMenuContainer.querySelectorAll('[data-role="menuitem"]'));
+        const usingFallback = !widthButtons.length;
+        if (usingFallback) {
+          widthButtons = Array.from(widthMenuContainer.querySelectorAll('div')).filter(div =>
+            div.className && typeof div.className === 'string' && div.className.includes('item')
+          );
         }
-      }
+        if (!widthButtons.length) { console.warn('[TVP LineWidth] No width buttons found'); return; }
+
+        let activeIndex = findActiveMenuItem(widthButtons);
+        if (activeIndex === -1) activeIndex = 0;
+        const nextIndex = (activeIndex + 1) % widthButtons.length;
+        console.log(`[TVP LineWidth] active=${activeIndex} next=${nextIndex} total=${widthButtons.length}${usingFallback ? ' [fallback selector]' : ''}`);
+        (widthButtons[nextIndex] as HTMLElement)?.click();
+      });
     }
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -236,6 +236,7 @@ features.set('Quick Toolbar', new QuickToolbar());
 features.set('Timeframe Scroll', new TimeframeScroll());
 features.set('Scroll Price Scale', new ScrollPriceScale());
 features.set('Zoom Chart', new ZoomChart());
+features.set('Limit Order Only', new LimitOrderOnly());
 
 // Create TVP background
 const tvp_background = document.createElement('div');

--- a/src/utils/findActiveMenuItem.ts
+++ b/src/utils/findActiveMenuItem.ts
@@ -1,0 +1,59 @@
+/**
+ * Finds the index of the "active" item in a list of menu elements.
+ * 
+ * Strategy (in order of priority):
+ *  1. Check for data-role="menuitem" active detection via class partial match ('active', 'isActive')
+ *  2. Check aria-selected / aria-current attributes  
+ *  3. Compare computed background-color or color via getComputedStyle — the active
+ *     item visually differs from its siblings even if class names are hashed by React
+ * 
+ * This approach is immune to React-generated CSS class name suffix changes (e.g., isActive-jFqVJoPk).
+ */
+function findActiveMenuItem(items: Element[]): number {
+  if (items.length === 0) return -1;
+
+  // Method 1: Partial class name match for 'active' or 'isActive'
+  // Use space-prefix check to avoid false matches like "interactive-xxx" containing "active-"
+  const byClass = items.findIndex(el => {
+    const cn = ' ' + (el as HTMLElement).className + ' '; // pad with spaces for word-boundary matching
+    return cn.includes(' isActive') || cn.includes(' active-');
+  });
+  if (byClass !== -1) return byClass;
+
+  // Method 2: aria-selected / aria-current attribute
+  const byAria = items.findIndex(el =>
+    el.getAttribute('aria-selected') === 'true' ||
+    el.getAttribute('aria-current') === 'true' ||
+    el.getAttribute('aria-pressed') === 'true'
+  );
+  if (byAria !== -1) return byAria;
+
+  // Method 3: Compare computed background-color and color — active items render differently
+  // Build a map of each items computed bg color and find the outlier
+  const styles = items.map(el => {
+    const s = getComputedStyle(el as HTMLElement);
+    return { bg: s.backgroundColor, color: s.color };
+  });
+
+  // Count occurrences of each bg color
+  const bgCounts: Record<string, number> = {};
+  styles.forEach(s => { bgCounts[s.bg] = (bgCounts[s.bg] || 0) + 1; });
+
+  // The active item is often the one with a unique/outlier background color
+  if (Object.keys(bgCounts).length > 1) {
+    const rareColor = Object.entries(bgCounts).sort((a, b) => a[1] - b[1])[0][0];
+    const byBg = styles.findIndex(s => s.bg === rareColor);
+    if (byBg !== -1) return byBg;
+  }
+
+  // Method 4: Check each element's children for an active indicator (space-padded to avoid interactive- match)
+  const byChildClass = items.findIndex(el => {
+    return Array.from(el.querySelectorAll('*')).some(child => {
+      const cn = ' ' + (child as HTMLElement).className + ' ';
+      return cn.includes(' isActive') || cn.includes(' active-');
+    });
+  });
+  if (byChildClass !== -1) return byChildClass;
+
+  return -1;
+}


### PR DESCRIPTION
This PR introduces a new feature and resolves a recent DOM-related bug.

### Changes
* **Limit Order Only**
  * Added a togglable feature to enforce Limit orders in the order panel.
  * Disables Market, Stop, Stop-Limit tabs, on-chart Buy/Sell buttons, and the DOM panel.
  * Auto-selects the Limit tab if other order types are active.

* **Auto Timeframe Colors Fix**
  * Implemented a multi-layered fallback selector to correctly identify the active timeframe button, fixing the breakage caused by TradingView's recent DOM updates.
  
   Closes #122
   Fixes #121  
