### PR TITLE
fix: Resolve ContextMenu clipping, overlay bugs, and menu state syncing (#6, #42, #44)

### DIFF
--- a/src/features/AutoTimeframeColors.ts
+++ b/src/features/AutoTimeframeColors.ts
@@ -129,8 +129,27 @@ class AutoTimeframeColors extends Feature {
 
         /* Update ColorPickerMenu position */
         // Calculate position
-        const offset = cm.element.getBoundingClientRect().right - cm.element.getBoundingClientRect().left + 2;
-        colorPickerCm.updatePosition([x + offset, y]);
+        const cmWidth = cm.element.getBoundingClientRect().right - cm.element.getBoundingClientRect().left;
+        let targetX = x + cmWidth + 2;
+
+        const menu = document.getElementById('tvp-menu');
+        if (menu && colorPickerCm.element) {
+          colorPickerCm.element.hidden = false;
+          colorPickerCm.element.style.visibility = 'hidden';
+
+          const pickerWidth = colorPickerCm.element.offsetWidth;
+          const menuWidth = window.innerWidth;
+
+          // If it flows off screen to the right, open to the left instead
+          if (targetX + pickerWidth > menuWidth) {
+            targetX = x - pickerWidth - 2;
+          }
+
+          colorPickerCm.element.style.visibility = 'visible';
+          colorPickerCm.element.hidden = true;
+        }
+
+        colorPickerCm.updatePosition([targetX, y]);
       })
     ]);
   }

--- a/src/utils/ContextMenu.ts
+++ b/src/utils/ContextMenu.ts
@@ -41,11 +41,11 @@ class ContextMenu {
 
   render(): HTMLElement {
     const container = document.createElement('div');
-    const menu = document.getElementById('tvp-menu');
-    if (!menu) return container;
-
     this.element = container;
     container.className = 'contextMenu';
+    
+    // Ensure it overlays over everything by appending to body and fixing position
+    container.style.position = 'fixed';
     
     // Calculate the width of the container without adding it to the DOM
     container.style.visibility = 'hidden';
@@ -57,10 +57,12 @@ class ContextMenu {
       if (container.classList.contains('tvp-light'))
         container.classList.remove('tvp-light');
     
+    document.body.appendChild(container);
+
     // Calculate the width
     const containerWidth = container.offsetWidth;
+    const menuWidth = window.innerWidth;
     
-    const menuWidth = window.innerWidth - menu.getBoundingClientRect().x;
     if (this.position[0] + containerWidth > menuWidth) {
       this.position[0] -= containerWidth;
     }
@@ -70,7 +72,6 @@ class ContextMenu {
     container.style.left = this.position[0] + 'px';
     container.style.top = this.position[1] + 'px';
 
-    menu.appendChild(container);
     this.listenForOutsideClicks();
 
     return container;

--- a/src/utils/TVPMenu.ts
+++ b/src/utils/TVPMenu.ts
@@ -77,8 +77,7 @@ class TVPMenu {
       const menu = document.getElementById('tvp-menu');
       const dots = container.querySelector('svg');
       if (!menu || !dots || feature.getContextMenuOptions().length === 0) return;
-      const x = dots.getBoundingClientRect().x - menu.getBoundingClientRect().x;
-      const cm = new ContextMenu([x, dots.getBoundingClientRect().y]);
+      const cm = new ContextMenu([dots.getBoundingClientRect().x, dots.getBoundingClientRect().y]);
       cm.renderList(feature.getContextMenuOptions());
     }
 
@@ -368,6 +367,9 @@ class TVPMenu {
 
     container.style.left = -container.getBoundingClientRect().width+'px';
     textBox.blur();
+
+    // Ensure all submenus (context menu, color pickers, etc) close when the menu gets closed via Keyboard / Escape
+    document.dispatchEvent(new MouseEvent('mousedown'));
   }
 
   isOpen() {


### PR DESCRIPTION

### Description
This PR addresses multiple menu-related UX issues to ensure feature sub-menus and popups behave reliably alongside the native TradingView interface without getting clipped or hanging around unexpectedly.

* **Fixes #6:** Forced submenus (such as ContextMenus and Color Pickers) to properly close via key presses. Closing the menu with `Escape` now triggers an underlying document-level `mousedown` ping that elegantly clears any open, listening context tools.
* **Fixes #42:** Added responsive bounds checking when opening wide submenus (e.g. timeframe color configs). The menus will seamlessly compute the available screen width and smartly open to the left if space on the right is constrained, preventing the menu from bleeding outside the viewport. 
<img width="1498" height="964" alt="Screenshot from 2026-04-08 09-00-32" src="https://github.com/user-attachments/assets/9e0bbe12-5ea0-45e6-9d29-b9d9bd3f5a54" />

* **Fixes #44:** Refactored the core underlying `ContextMenu` rendering API. Context menu containers are now appended directly to `document.body` with `position: fixed`. This breaks modals out of the local `.tvp-menu` z-index stacking limitations so they permanently and cleanly overlay on top of all menu items and the page background.
<img width="826" height="237" alt="Screenshot from 2026-04-08 09-13-33" src="https://github.com/user-attachments/assets/a6cba548-c995-4873-bc4d-83a419d44bf1" />

***

